### PR TITLE
type children changed in Xmlel struct: admits a list of (just one) st…

### DIFF
--- a/lib/exampple/xml/xmlel.ex
+++ b/lib/exampple/xml/xmlel.ex
@@ -11,7 +11,7 @@ defmodule Exampple.Xml.Xmlel do
   @type attrs :: %{attr_name => attr_value}
 
   @type t :: %__MODULE__{name: binary, attrs: attrs, children: [t]}
-  @type children :: [t]
+  @type children :: [t] | [String.t()]
 
   defstruct name: nil, attrs: %{}, children: []
 


### PR DESCRIPTION
I had a complain from dialyzer in a project and checked that passing a list with one string in children should be allowed by the type.